### PR TITLE
Directly poll SharedConstants for DataVersion

### DIFF
--- a/v1.20.6/src/main/java/dev/kitteh/cardboardbox/v1_20_6/Box.java
+++ b/v1.20.6/src/main/java/dev/kitteh/cardboardbox/v1_20_6/Box.java
@@ -2,12 +2,12 @@ package dev.kitteh.cardboardbox.v1_20_6;
 
 import com.google.common.base.Preconditions;
 import com.mojang.serialization.Dynamic;
+import net.minecraft.SharedConstants;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtOps;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.datafix.fixes.References;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
-import org.bukkit.craftbukkit.util.CraftMagicNumbers;
 import org.bukkit.inventory.ItemStack;
 
 import java.io.IOException;
@@ -17,7 +17,7 @@ public class Box implements dev.kitteh.cardboardbox.api.Box {
         return itemStack.equals(deserializeItem(serializeItem(itemStack)));
     }
 
-    private static final int DATA_VERSION = CraftMagicNumbers.INSTANCE.getDataVersion();
+    private static final int DATA_VERSION = SharedConstants.getCurrentVersion().getDataVersion().getVersion();
 
     @Override
     public byte[] serializeItem(ItemStack item) {

--- a/v1.21.3/src/main/java/dev/kitteh/cardboardbox/v1_21_3/Box.java
+++ b/v1.21.3/src/main/java/dev/kitteh/cardboardbox/v1_21_3/Box.java
@@ -2,12 +2,12 @@ package dev.kitteh.cardboardbox.v1_21_3;
 
 import com.google.common.base.Preconditions;
 import com.mojang.serialization.Dynamic;
+import net.minecraft.SharedConstants;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtOps;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.datafix.fixes.References;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
-import org.bukkit.craftbukkit.util.CraftMagicNumbers;
 import org.bukkit.inventory.ItemStack;
 
 import java.io.IOException;
@@ -17,7 +17,7 @@ public class Box implements dev.kitteh.cardboardbox.api.Box {
         return itemStack.equals(deserializeItem(serializeItem(itemStack)));
     }
 
-    private static final int DATA_VERSION = CraftMagicNumbers.INSTANCE.getDataVersion();
+    private static final int DATA_VERSION = SharedConstants.getCurrentVersion().getDataVersion().getVersion();
 
     @Override
     public byte[] serializeItem(ItemStack item) {

--- a/v1.21.4/src/main/java/dev/kitteh/cardboardbox/v1_21_4/Box.java
+++ b/v1.21.4/src/main/java/dev/kitteh/cardboardbox/v1_21_4/Box.java
@@ -2,12 +2,12 @@ package dev.kitteh.cardboardbox.v1_21_4;
 
 import com.google.common.base.Preconditions;
 import com.mojang.serialization.Dynamic;
+import net.minecraft.SharedConstants;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtOps;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.datafix.fixes.References;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
-import org.bukkit.craftbukkit.util.CraftMagicNumbers;
 import org.bukkit.inventory.ItemStack;
 
 import java.io.IOException;
@@ -17,7 +17,7 @@ public class Box implements dev.kitteh.cardboardbox.api.Box {
         return itemStack.equals(deserializeItem(serializeItem(itemStack)));
     }
 
-    private static final int DATA_VERSION = CraftMagicNumbers.INSTANCE.getDataVersion();
+    private static final int DATA_VERSION = SharedConstants.getCurrentVersion().getDataVersion().getVersion();
 
     @Override
     public byte[] serializeItem(ItemStack item) {

--- a/v1.21/src/main/java/dev/kitteh/cardboardbox/v1_21/Box.java
+++ b/v1.21/src/main/java/dev/kitteh/cardboardbox/v1_21/Box.java
@@ -2,12 +2,12 @@ package dev.kitteh.cardboardbox.v1_21;
 
 import com.google.common.base.Preconditions;
 import com.mojang.serialization.Dynamic;
+import net.minecraft.SharedConstants;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtOps;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.datafix.fixes.References;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
-import org.bukkit.craftbukkit.util.CraftMagicNumbers;
 import org.bukkit.inventory.ItemStack;
 
 import java.io.IOException;
@@ -17,7 +17,7 @@ public class Box implements dev.kitteh.cardboardbox.api.Box {
         return itemStack.equals(deserializeItem(serializeItem(itemStack)));
     }
 
-    private static final int DATA_VERSION = CraftMagicNumbers.INSTANCE.getDataVersion();
+    private static final int DATA_VERSION = SharedConstants.getCurrentVersion().getDataVersion().getVersion();
 
     @Override
     public byte[] serializeItem(ItemStack item) {


### PR DESCRIPTION
Hello, good day!

This PR will make the serializers directly poll the data version from NMS' SharedConstants to avoid the unsafe CraftMagicNumbers Bukkit implementation. 

This issue came about due to Arclight not having an implementation for it, making plugins depending on CardboardBox crash on start-up.

Let me know if you want any other changes!